### PR TITLE
removed app.import for semanti UI in ember-cli-build.js

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -19,7 +19,5 @@ module.exports = function(defaults) {
   // modules that you would like to import into your application
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
-  app.import('bower_components/semantic-ui/dist/semantic.js');
-  app.import('bower_components/semantic-ui/dist/semantic.css');
   return app.toTree();
 };


### PR DESCRIPTION
Manual importation of semantic ui may be including a second copy of the library introducting conflicts.